### PR TITLE
feat: Qdrant semantic search tool

### DIFF
--- a/config/config.json.template
+++ b/config/config.json.template
@@ -28,6 +28,18 @@
     "vision.ts": true,
     "filesystem.ts": true,
     "weather.ts": true,
-    "web_browser.ts": true
+    "web_browser.ts": true,
+    "qdrant.ts": false
+  },
+  "tools": {
+    "qdrant": {
+      "stores": {
+        "my-store": {
+          "url": "http://your-qdrant-server:6333",
+          "collection": "your_collection",
+          "dimensions": 768
+        }
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@qdrant/js-client-rest": "^1.17.0",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^12.6.2",
         "cors": "^2.8.6",
@@ -1127,6 +1128,33 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.17.0.tgz",
+      "integrity": "sha512-aZFQeirWVqWAa1a8vJ957LMzcXkFHGbsoRhzc8AkGfg6V0jtK8PlG8/eyyc2xhYsR961FDDx1Tx6nyE0K7lS+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "pnpm": ">=8"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5018,7 +5046,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5036,6 +5063,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@qdrant/js-client-rest": "^1.17.0",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",

--- a/tools/qdrant.ts
+++ b/tools/qdrant.ts
@@ -1,0 +1,255 @@
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { loadConfig } from '../src/config-manager.js';
+import { createEmbedding } from '../src/llm-provider.js';
+
+const DEBUG = process.env.QDRANT_DEBUG === 'true' || process.env.QDRANT_DEBUG === '1';
+
+function debug(...args: unknown[]) {
+    if (DEBUG) console.log('[Qdrant:DEBUG]', ...args);
+}
+
+interface QdrantStoreConfig {
+    url: string;
+    apiKey?: string;
+    collection: string;
+    dimensions?: number;
+}
+
+interface QdrantArgs {
+    action: 'search';
+    store: string;
+    query: string;
+    limit?: number;
+    score_threshold?: number;
+    _context?: {
+        agentId?: string;
+        toolConfig?: {
+            stores?: Record<string, QdrantStoreConfig>;
+        };
+    };
+}
+
+/**
+ * Build the list of available store names at load time so we can
+ * put them in the tool definition as an enum for the LLM.
+ */
+function getAvailableStoreNames(): string[] {
+    const names: string[] = [];
+
+    // From config
+    try {
+        const config = loadConfig();
+        const stores = (config as any).tools?.qdrant?.stores;
+        if (stores && typeof stores === 'object') {
+            for (const [name, store] of Object.entries(stores)) {
+                if ((store as any)?.url) names.push(name);
+            }
+        }
+    } catch { /* config not available yet */ }
+
+    return names;
+}
+
+const availableStores = getAvailableStoreNames();
+debug('available stores at load:', availableStores);
+
+function resolveStoreConfig(storeName: string, toolConfig?: QdrantArgs['_context']): QdrantStoreConfig | { error: string } {
+    const stores = toolConfig?.toolConfig?.stores;
+
+    // Try configured stores first (skip entries with empty url — treat as unconfigured)
+    if (stores) {
+        const validStores = Object.fromEntries(
+            Object.entries(stores).filter(([, s]) => s.url)
+        );
+        if (Object.keys(validStores).length > 0) {
+            const store = validStores[storeName];
+            if (!store) {
+                const available = Object.keys(validStores).join(', ');
+                return { error: `Store "${storeName}" not found. Available stores: ${available}` };
+            }
+            // Fall back to QDRANT_API_KEY env var if store has no apiKey
+            if (!store.apiKey && process.env.QDRANT_API_KEY) {
+                store.apiKey = process.env.QDRANT_API_KEY;
+            }
+            return store;
+        }
+    }
+
+    // Fall back to full config file (not per-agent toolConfig)
+    try {
+        const config = loadConfig();
+        const configStores = (config as any).tools?.qdrant?.stores;
+        if (configStores && typeof configStores === 'object') {
+            const validStores = Object.fromEntries(
+                Object.entries(configStores).filter(([, s]) => (s as any)?.url)
+            );
+            if (Object.keys(validStores).length > 0) {
+                const store = validStores[storeName] as QdrantStoreConfig | undefined;
+                if (!store) {
+                    const available = Object.keys(validStores).join(', ');
+                    return { error: `Store "${storeName}" not found. Available stores: ${available}` };
+                }
+                if (!store.apiKey && process.env.QDRANT_API_KEY) {
+                    store.apiKey = process.env.QDRANT_API_KEY;
+                }
+                return store;
+            }
+        }
+    } catch { /* config not available */ }
+
+    return { error: 'No Qdrant stores configured. Add stores to tools.qdrant.stores in config.' };
+}
+
+function resolveEmbeddingProvider(): { baseUrl: string; modelId: string; apiKey?: string } | { error: string } {
+    const config = loadConfig();
+    const embeddingsModel = config.memory?.embeddingsModel;
+
+    if (!embeddingsModel) {
+        return { error: 'No embedding model configured. Set memory.embeddingsModel in config.' };
+    }
+
+    const providers = config.providers || [];
+    let providerConfig = providers.find((p: any) => p.description === embeddingsModel);
+    if (!providerConfig) {
+        providerConfig = providers.find((p: any) => p.model === embeddingsModel);
+    }
+
+    if (!providerConfig) {
+        return { error: `Embedding provider "${embeddingsModel}" not found in configured providers.` };
+    }
+
+    return {
+        baseUrl: providerConfig.endpoint,
+        modelId: providerConfig.model,
+        apiKey: providerConfig.apiKey,
+    };
+}
+
+// Build store property — include enum of known names so the LLM picks the right one
+const storeProperty: Record<string, any> = {
+    type: 'string',
+    description: 'The name of the Qdrant store to search.',
+};
+if (availableStores.length > 0) {
+    storeProperty.enum = availableStores;
+    storeProperty.description = `The Qdrant store to search. Available: ${availableStores.join(', ')}`;
+}
+
+export default {
+    definition: {
+        name: 'qdrant',
+        description: `Search a Qdrant vector store semantically. Provide a natural language query and store name.${availableStores.length > 0 ? ` Available stores: ${availableStores.join(', ')}` : ''}`,
+        parameters: {
+            type: 'object',
+            properties: {
+                action: {
+                    type: 'string',
+                    enum: ['search'],
+                    description: 'The action to perform. Currently only "search" is supported.',
+                },
+                store: storeProperty,
+                query: {
+                    type: 'string',
+                    description: 'Natural language search query.',
+                },
+                limit: {
+                    type: 'number',
+                    description: 'Maximum number of results to return (default: 5).',
+                },
+                score_threshold: {
+                    type: 'number',
+                    description: 'Minimum similarity score threshold for results.',
+                },
+            },
+            required: ['action', 'store', 'query'],
+        },
+    },
+
+    handler: async (args: QdrantArgs) => {
+        const { action, store: storeName, query, limit = 5, score_threshold, _context } = args;
+
+        debug('handler called:', { action, store: storeName, query: query?.slice(0, 80), limit, score_threshold });
+        debug('toolConfig stores:', _context?.toolConfig?.stores ? Object.keys(_context.toolConfig.stores) : 'none');
+
+        if (action !== 'search') {
+            return { error: `Unknown action: "${action}". Only "search" is supported.` };
+        }
+
+        if (!query || query.trim().length === 0) {
+            return { error: 'query is required and must not be empty.' };
+        }
+
+        // Resolve store config
+        const storeConfig = resolveStoreConfig(storeName, _context);
+        if ('error' in storeConfig) {
+            debug('store resolution failed:', storeConfig.error);
+            return storeConfig;
+        }
+        debug('resolved store:', { url: storeConfig.url, collection: storeConfig.collection, dimensions: storeConfig.dimensions, hasApiKey: !!storeConfig.apiKey });
+
+        // Resolve embedding provider
+        const embeddingProvider = resolveEmbeddingProvider();
+        if ('error' in embeddingProvider) {
+            debug('embedding provider resolution failed:', embeddingProvider.error);
+            return embeddingProvider;
+        }
+        debug('resolved embedding provider:', { baseUrl: embeddingProvider.baseUrl, modelId: embeddingProvider.modelId });
+
+        try {
+            // Generate embedding for the query
+            debug('generating embedding for query...');
+            const embeddings = await createEmbedding(embeddingProvider, query);
+            let vector = embeddings[0];
+            debug('embedding generated, dimensions:', vector?.length);
+
+            if (!vector || vector.length === 0) {
+                debug('ERROR: empty embedding vector returned');
+                return { error: 'Embedding returned empty vector. Check your embedding provider.' };
+            }
+
+            // Truncate vector to match store dimensions (Matryoshka embeddings)
+            if (storeConfig.dimensions && vector.length > storeConfig.dimensions) {
+                debug(`truncating embedding from ${vector.length} to ${storeConfig.dimensions} dimensions`);
+                vector = vector.slice(0, storeConfig.dimensions);
+            }
+
+            // Search Qdrant
+            const client = new QdrantClient({
+                url: storeConfig.url,
+                apiKey: storeConfig.apiKey,
+                checkCompatibility: false,
+            });
+            debug('QdrantClient created, searching collection:', storeConfig.collection);
+
+            const searchParams: any = {
+                vector,
+                limit,
+            };
+            if (score_threshold !== undefined) {
+                searchParams.score_threshold = score_threshold;
+            }
+            debug('search params:', { vectorDims: vector.length, limit, score_threshold });
+
+            const searchResult = await client.search(storeConfig.collection, searchParams);
+            debug('search returned', searchResult.length, 'results');
+
+            if (searchResult.length > 0) {
+                debug('top result:', { id: searchResult[0].id, score: searchResult[0].score, payloadKeys: Object.keys(searchResult[0].payload || {}) });
+            }
+
+            return {
+                store: storeName,
+                collection: storeConfig.collection,
+                query,
+                results: searchResult.map((point: any) => ({
+                    id: point.id,
+                    score: point.score,
+                    payload: point.payload,
+                })),
+            };
+        } catch (err: any) {
+            debug('ERROR:', err.message, err.stack);
+            return { error: `Qdrant search failed: ${err.message}` };
+        }
+    },
+};

--- a/tools/tests/qdrant.test.ts
+++ b/tools/tests/qdrant.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @qdrant/js-client-rest
+const mockSearch = vi.fn();
+vi.mock('@qdrant/js-client-rest', () => {
+    return {
+        QdrantClient: class MockQdrantClient {
+            url: string;
+            apiKey?: string;
+            constructor(opts: any) {
+                this.url = opts.url;
+                this.apiKey = opts.apiKey;
+                MockQdrantClient._lastInstance = this;
+                MockQdrantClient._lastOpts = opts;
+            }
+            search = mockSearch;
+            static _lastInstance: any;
+            static _lastOpts: any;
+        },
+    };
+});
+
+// Mock config-manager
+const mockLoadConfig = vi.fn();
+vi.mock('../../src/config-manager.js', () => ({
+    loadConfig: () => mockLoadConfig(),
+}));
+
+// Mock llm-provider
+const mockCreateEmbedding = vi.fn();
+vi.mock('../../src/llm-provider.js', () => ({
+    createEmbedding: (...args: any[]) => mockCreateEmbedding(...args),
+}));
+
+import { QdrantClient } from '@qdrant/js-client-rest';
+import tool from '../qdrant.js';
+
+const MockQdrantClient = QdrantClient as any;
+
+function defaultConfig() {
+    return {
+        memory: {
+            useEmbeddings: true,
+            embeddingsModel: 'text-embedding-nomic-embed-text-v1.5',
+        },
+        providers: [
+            {
+                description: 'text-embedding-nomic-embed-text-v1.5',
+                endpoint: 'http://192.168.0.103:1234',
+                model: 'text-embedding-nomic-embed-text-v1.5',
+            },
+        ],
+    };
+}
+
+function storeContext(stores: Record<string, any> = {}) {
+    return {
+        agentId: 'test-agent',
+        toolConfig: { stores },
+    };
+}
+
+describe('qdrant tool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.QDRANT_URL;
+        delete process.env.QDRANT_API_KEY;
+        delete process.env.QDRANT_COLLECTION;
+        mockLoadConfig.mockReturnValue(defaultConfig());
+        mockCreateEmbedding.mockResolvedValue([[0.1, 0.2, 0.3]]);
+        mockSearch.mockResolvedValue([]);
+    });
+
+    describe('definition', () => {
+        it('should export a valid tool definition', () => {
+            expect(tool.definition.name).toBe('qdrant');
+            expect(tool.definition.parameters.type).toBe('object');
+            expect(tool.definition.parameters.required).toEqual(['action', 'store', 'query']);
+            expect(tool.definition.parameters.properties.action.enum).toEqual(['search']);
+        });
+
+        it('should have a handler function', () => {
+            expect(typeof tool.handler).toBe('function');
+        });
+    });
+
+    describe('validation', () => {
+        it('should reject unknown actions', async () => {
+            const result = await tool.handler({
+                action: 'delete' as any,
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+            expect(result.error).toMatch(/Unknown action/);
+        });
+
+        it('should reject empty query', async () => {
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: '   ',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+            expect(result.error).toMatch(/query is required/);
+        });
+
+        it('should reject unknown store', async () => {
+            const result = await tool.handler({
+                action: 'search',
+                store: 'nonexistent',
+                query: 'test query',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+            expect(result.error).toMatch(/Store "nonexistent" not found/);
+            expect(result.error).toMatch(/Available stores: kb/);
+        });
+
+        it('should reject when no stores configured', async () => {
+            const result = await tool.handler({
+                action: 'search',
+                store: 'anything',
+                query: 'test query',
+            });
+            expect(result.error).toMatch(/No Qdrant stores configured/);
+        });
+
+        it('should reject when embedding model not configured', async () => {
+            mockLoadConfig.mockReturnValue({ memory: {}, providers: [] });
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+            expect(result.error).toMatch(/No embedding model configured/);
+        });
+
+        it('should reject when embedding provider not found in providers list', async () => {
+            mockLoadConfig.mockReturnValue({
+                memory: { embeddingsModel: 'nonexistent-model' },
+                providers: [],
+            });
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+            expect(result.error).toMatch(/Embedding provider "nonexistent-model" not found/);
+        });
+    });
+
+    describe('config resolution', () => {
+        it('should use toolConfig stores when provided', async () => {
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test query',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant-server:6333', apiKey: 'key123', collection: 'knowledge_base' },
+                }),
+            });
+
+            expect(result.error).toBeUndefined();
+            expect(MockQdrantClient._lastOpts).toEqual({
+                url: 'http://qdrant-server:6333',
+                apiKey: 'key123',
+                checkCompatibility: false,
+            });
+        });
+
+        it('should fall back to global config when toolConfig stores are empty', async () => {
+            mockLoadConfig.mockReturnValue({
+                ...defaultConfig(),
+                tools: {
+                    qdrant: {
+                        stores: {
+                            mystore: { url: 'http://config-qdrant:6333', collection: 'from_config' },
+                        },
+                    },
+                },
+            });
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'mystore',
+                query: 'test query',
+                _context: storeContext({}),
+            });
+
+            expect(result.error).toBeUndefined();
+            expect(MockQdrantClient._lastOpts).toEqual({
+                url: 'http://config-qdrant:6333',
+                apiKey: undefined,
+                checkCompatibility: false,
+            });
+            expect(mockSearch).toHaveBeenCalledWith('from_config', expect.any(Object));
+        });
+
+        it('should use QDRANT_API_KEY env var when store has no apiKey', async () => {
+            process.env.QDRANT_API_KEY = 'env-secret-key';
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test query',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', collection: 'c' },
+                }),
+            });
+
+            expect(result.error).toBeUndefined();
+            expect(MockQdrantClient._lastOpts).toEqual({
+                url: 'http://qdrant:6333',
+                apiKey: 'env-secret-key',
+                checkCompatibility: false,
+            });
+        });
+
+        it('should prefer store apiKey over QDRANT_API_KEY env var', async () => {
+            process.env.QDRANT_API_KEY = 'env-key';
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test query',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', apiKey: 'store-key', collection: 'c' },
+                }),
+            });
+
+            expect(result.error).toBeUndefined();
+            expect(MockQdrantClient._lastOpts).toEqual({
+                url: 'http://qdrant:6333',
+                apiKey: 'store-key',
+                checkCompatibility: false,
+            });
+        });
+
+        it('should resolve embedding provider by description', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            expect(mockCreateEmbedding).toHaveBeenCalledWith(
+                {
+                    baseUrl: 'http://192.168.0.103:1234',
+                    modelId: 'text-embedding-nomic-embed-text-v1.5',
+                    apiKey: undefined,
+                },
+                'test',
+            );
+        });
+
+        it('should resolve embedding provider by model name as fallback', async () => {
+            mockLoadConfig.mockReturnValue({
+                memory: { embeddingsModel: 'text-embedding-nomic-embed-text-v1.5' },
+                providers: [
+                    {
+                        description: 'Different description',
+                        endpoint: 'http://192.168.0.103:1234',
+                        model: 'text-embedding-nomic-embed-text-v1.5',
+                        apiKey: 'model-key',
+                    },
+                ],
+            });
+
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            expect(mockCreateEmbedding).toHaveBeenCalledWith(
+                {
+                    baseUrl: 'http://192.168.0.103:1234',
+                    modelId: 'text-embedding-nomic-embed-text-v1.5',
+                    apiKey: 'model-key',
+                },
+                'test',
+            );
+        });
+    });
+
+    describe('search', () => {
+        it('should embed query and search Qdrant, returning mapped results', async () => {
+            mockCreateEmbedding.mockResolvedValue([[0.1, 0.2, 0.3]]);
+            mockSearch.mockResolvedValue([
+                { id: 'abc-123', score: 0.95, payload: { title: 'Result 1', text: 'Content 1' } },
+                { id: 'def-456', score: 0.87, payload: { title: 'Result 2', text: 'Content 2' } },
+            ]);
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'how to deploy',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', collection: 'knowledge_base' },
+                }),
+            });
+
+            expect(result.store).toBe('kb');
+            expect(result.collection).toBe('knowledge_base');
+            expect(result.query).toBe('how to deploy');
+            expect(result.results).toHaveLength(2);
+            expect(result.results[0]).toEqual({
+                id: 'abc-123',
+                score: 0.95,
+                payload: { title: 'Result 1', text: 'Content 1' },
+            });
+            expect(result.results[1]).toEqual({
+                id: 'def-456',
+                score: 0.87,
+                payload: { title: 'Result 2', text: 'Content 2' },
+            });
+        });
+
+        it('should return empty results when no matches', async () => {
+            mockSearch.mockResolvedValue([]);
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'obscure topic',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', collection: 'c' },
+                }),
+            });
+
+            expect(result.results).toEqual([]);
+        });
+
+        it('should handle Qdrant errors gracefully', async () => {
+            mockSearch.mockRejectedValue(new Error('Connection refused'));
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', collection: 'c' },
+                }),
+            });
+
+            expect(result.error).toMatch(/Qdrant search failed.*Connection refused/);
+        });
+
+        it('should handle embedding errors gracefully', async () => {
+            mockCreateEmbedding.mockRejectedValue(new Error('Embedding API error: 503'));
+
+            const result = await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({
+                    kb: { url: 'http://qdrant:6333', collection: 'c' },
+                }),
+            });
+
+            expect(result.error).toMatch(/Qdrant search failed.*Embedding API error/);
+        });
+    });
+
+    describe('options passthrough', () => {
+        it('should pass default limit of 5', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            expect(mockSearch).toHaveBeenCalledWith('c', {
+                vector: [0.1, 0.2, 0.3],
+                limit: 5,
+            });
+        });
+
+        it('should pass custom limit', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                limit: 10,
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            expect(mockSearch).toHaveBeenCalledWith('c', {
+                vector: [0.1, 0.2, 0.3],
+                limit: 10,
+            });
+        });
+
+        it('should pass score_threshold when provided', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                score_threshold: 0.8,
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            expect(mockSearch).toHaveBeenCalledWith('c', {
+                vector: [0.1, 0.2, 0.3],
+                limit: 5,
+                score_threshold: 0.8,
+            });
+        });
+
+        it('should not include score_threshold when not provided', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({ kb: { url: 'http://q:6333', collection: 'c' } }),
+            });
+
+            const searchParams = mockSearch.mock.calls[0][1];
+            expect(searchParams).not.toHaveProperty('score_threshold');
+        });
+    });
+
+    describe('dimensions truncation', () => {
+        it('should truncate embedding to store dimensions', async () => {
+            // Embedding model returns 768 dims, store expects 192
+            const fullVector = Array.from({ length: 768 }, (_, i) => i * 0.001);
+            mockCreateEmbedding.mockResolvedValue([fullVector]);
+
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({
+                    kb: { url: 'http://q:6333', collection: 'c', dimensions: 192 },
+                }),
+            });
+
+            const searchParams = mockSearch.mock.calls[0][1];
+            expect(searchParams.vector).toHaveLength(192);
+            expect(searchParams.vector).toEqual(fullVector.slice(0, 192));
+        });
+
+        it('should not truncate when embedding matches store dimensions', async () => {
+            const vector = Array.from({ length: 192 }, (_, i) => i * 0.001);
+            mockCreateEmbedding.mockResolvedValue([vector]);
+
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({
+                    kb: { url: 'http://q:6333', collection: 'c', dimensions: 192 },
+                }),
+            });
+
+            const searchParams = mockSearch.mock.calls[0][1];
+            expect(searchParams.vector).toHaveLength(192);
+        });
+
+        it('should not truncate when no dimensions configured', async () => {
+            await tool.handler({
+                action: 'search',
+                store: 'kb',
+                query: 'test',
+                _context: storeContext({
+                    kb: { url: 'http://q:6333', collection: 'c' },
+                }),
+            });
+
+            const searchParams = mockSearch.mock.calls[0][1];
+            expect(searchParams.vector).toEqual([0.1, 0.2, 0.3]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add Qdrant vector search tool for semantic search over external knowledge bases
- Configurable stores with URL, collection, and dimensions in `config.json`
- Includes comprehensive unit tests

## Test plan
- [ ] Configure a Qdrant store in config and verify tool discovers it
- [ ] Test search queries return relevant results
- [ ] Verify error handling for unreachable Qdrant instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)