### PR TITLE
feat: Google Tasks tool with OAuth 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "setup:google": "tsx scripts/google-auth.ts"
   },
   "keywords": [],
   "author": "",
@@ -20,6 +21,7 @@
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
     "express": "^5.2.1",
+    "googleapis": "^146.0.0",
     "node-cron": "^4.2.1",
     "puppeteer": "^24.37.3",
     "qrcode": "^1.5.4",

--- a/scripts/google-auth.ts
+++ b/scripts/google-auth.ts
@@ -1,0 +1,122 @@
+import { google } from 'googleapis';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const ENV_PATH = path.resolve(process.cwd(), '.env');
+
+// Load .env file into process.env
+if (fs.existsSync(ENV_PATH)) {
+    const envContent = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const line of envContent.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eqIndex = trimmed.indexOf('=');
+        if (eqIndex === -1) continue;
+        const key = trimmed.slice(0, eqIndex).trim();
+        const value = trimmed.slice(eqIndex + 1).trim();
+        if (!process.env[key]) {
+            process.env[key] = value;
+        }
+    }
+}
+
+const clientId = process.env.GOOGLE_CLIENT_ID;
+const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+if (!clientId || !clientSecret) {
+    console.error('Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET in .env');
+    console.error('1. Create an OAuth 2.0 Client ID (Desktop app) at console.cloud.google.com');
+    console.error('2. Add http://localhost:3456/callback as an authorized redirect URI');
+    console.error('3. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env');
+    process.exit(1);
+}
+
+const REDIRECT_URI = 'http://localhost:3456/callback';
+const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, REDIRECT_URI);
+
+const authUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    prompt: 'consent',
+    scope: ['https://www.googleapis.com/auth/tasks'],
+});
+
+const server = http.createServer(async (req, res) => {
+    if (!req.url?.startsWith('/callback')) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+    }
+
+    const url = new URL(req.url, `http://localhost:3456`);
+    const code = url.searchParams.get('code');
+
+    if (!code) {
+        res.writeHead(400);
+        res.end('Missing authorization code');
+        return;
+    }
+
+    try {
+        const { tokens } = await oauth2Client.getToken(code);
+        const refreshToken = tokens.refresh_token;
+
+        if (!refreshToken) {
+            res.writeHead(500);
+            res.end('No refresh token received. Try revoking access at myaccount.google.com/permissions and re-running.');
+            server.close();
+            process.exit(1);
+            return;
+        }
+
+        // Update .env file
+        let envContent = '';
+        if (fs.existsSync(ENV_PATH)) {
+            envContent = fs.readFileSync(ENV_PATH, 'utf-8');
+        }
+
+        if (envContent.includes('GOOGLE_REFRESH_TOKEN=')) {
+            envContent = envContent.replace(/GOOGLE_REFRESH_TOKEN=.*/, `GOOGLE_REFRESH_TOKEN=${refreshToken}`);
+        } else {
+            if (envContent.length > 0 && !envContent.endsWith('\n')) {
+                envContent += '\n';
+            }
+            envContent += `GOOGLE_REFRESH_TOKEN=${refreshToken}\n`;
+        }
+
+        fs.writeFileSync(ENV_PATH, envContent);
+
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<h1>Authorization successful!</h1><p>You can close this tab. Refresh token has been saved to .env</p>');
+
+        console.log('\nRefresh token saved to .env');
+        console.log('You can now enable google_tasks.ts in your agent config.');
+
+        server.close();
+        process.exit(0);
+    } catch (err: any) {
+        res.writeHead(500);
+        res.end(`Token exchange failed: ${err.message}`);
+        server.close();
+        process.exit(1);
+    }
+});
+
+server.listen(3456, () => {
+    console.log('Opening browser for Google authorization...');
+    console.log(`If the browser doesn't open, visit:\n${authUrl}\n`);
+
+    const platform = process.platform;
+    try {
+        if (platform === 'darwin') {
+            execSync(`open "${authUrl}"`);
+        } else if (platform === 'win32') {
+            execSync(`start "${authUrl}"`);
+        } else {
+            execSync(`xdg-open "${authUrl}"`);
+        }
+    } catch {
+        // Browser open failed — URL is already printed above
+    }
+});

--- a/tools/google_tasks.ts
+++ b/tools/google_tasks.ts
@@ -1,0 +1,172 @@
+import { google } from 'googleapis';
+
+type Action = 'list_tasklists' | 'list_tasks' | 'add_task' | 'update_task';
+
+interface GoogleTasksArgs {
+    action: Action;
+    tasklist_id?: string;
+    task_id?: string;
+    title?: string;
+    notes?: string;
+    due?: string;
+    status?: 'needsAction' | 'completed';
+}
+
+function getClient() {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+    if (!clientId || !clientSecret || !refreshToken) {
+        throw new Error('Missing Google credentials. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REFRESH_TOKEN in .env');
+    }
+
+    const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
+    oauth2Client.setCredentials({ refresh_token: refreshToken });
+    return google.tasks({ version: 'v1', auth: oauth2Client });
+}
+
+function toRfc3339(dateStr: string): string {
+    return `${dateStr}T00:00:00.000Z`;
+}
+
+export default {
+    definition: {
+        name: 'google_tasks',
+        description: 'Manage Google Tasks: list task lists, list tasks, add tasks, and update tasks.',
+        parameters: {
+            type: 'object',
+            properties: {
+                action: {
+                    type: 'string',
+                    enum: ['list_tasklists', 'list_tasks', 'add_task', 'update_task'],
+                    description: 'The action to perform.'
+                },
+                tasklist_id: {
+                    type: 'string',
+                    description: 'The task list ID. Required for list_tasks, add_task, and update_task.'
+                },
+                task_id: {
+                    type: 'string',
+                    description: 'The task ID. Required for update_task.'
+                },
+                title: {
+                    type: 'string',
+                    description: 'Task title. Required for add_task, optional for update_task.'
+                },
+                notes: {
+                    type: 'string',
+                    description: 'Task notes/description. Optional.'
+                },
+                due: {
+                    type: 'string',
+                    description: 'Due date in YYYY-MM-DD format. Optional.'
+                },
+                status: {
+                    type: 'string',
+                    enum: ['needsAction', 'completed'],
+                    description: 'Task status. Only for update_task.'
+                }
+            },
+            required: ['action']
+        }
+    },
+    handler: async (args: GoogleTasksArgs) => {
+        try {
+            const tasksApi = getClient();
+
+            switch (args.action) {
+                case 'list_tasklists': {
+                    const res = await tasksApi.tasklists.list({ maxResults: 100 });
+                    const items = res.data.items || [];
+                    return {
+                        tasklists: items.map(tl => ({
+                            id: tl.id,
+                            title: tl.title
+                        }))
+                    };
+                }
+
+                case 'list_tasks': {
+                    if (!args.tasklist_id) {
+                        return { error: 'tasklist_id is required for list_tasks' };
+                    }
+                    const res = await tasksApi.tasks.list({
+                        tasklist: args.tasklist_id,
+                        maxResults: 100,
+                        showCompleted: true,
+                        showHidden: true
+                    });
+                    const items = res.data.items || [];
+                    return {
+                        tasks: items.map(t => ({
+                            id: t.id,
+                            title: t.title,
+                            notes: t.notes || null,
+                            status: t.status,
+                            due: t.due || null
+                        }))
+                    };
+                }
+
+                case 'add_task': {
+                    if (!args.tasklist_id) {
+                        return { error: 'tasklist_id is required for add_task' };
+                    }
+                    if (!args.title) {
+                        return { error: 'title is required for add_task' };
+                    }
+                    const body: Record<string, string> = { title: args.title };
+                    if (args.notes) body.notes = args.notes;
+                    if (args.due) body.due = toRfc3339(args.due);
+
+                    const res = await tasksApi.tasks.insert({
+                        tasklist: args.tasklist_id,
+                        requestBody: body
+                    });
+                    return {
+                        created: {
+                            id: res.data.id,
+                            title: res.data.title,
+                            status: res.data.status,
+                            due: res.data.due || null
+                        }
+                    };
+                }
+
+                case 'update_task': {
+                    if (!args.tasklist_id) {
+                        return { error: 'tasklist_id is required for update_task' };
+                    }
+                    if (!args.task_id) {
+                        return { error: 'task_id is required for update_task' };
+                    }
+                    const body: Record<string, string> = {};
+                    if (args.title) body.title = args.title;
+                    if (args.notes) body.notes = args.notes;
+                    if (args.due) body.due = toRfc3339(args.due);
+                    if (args.status) body.status = args.status;
+
+                    const res = await tasksApi.tasks.patch({
+                        tasklist: args.tasklist_id,
+                        task: args.task_id,
+                        requestBody: body
+                    });
+                    return {
+                        updated: {
+                            id: res.data.id,
+                            title: res.data.title,
+                            status: res.data.status,
+                            due: res.data.due || null
+                        }
+                    };
+                }
+
+                default:
+                    return { error: `Unknown action: ${args.action}` };
+            }
+        } catch (err: any) {
+            return { error: err.message || 'Google Tasks API error' };
+        }
+    }
+};

--- a/tools/tests/google_tasks.integration.test.ts
+++ b/tools/tests/google_tasks.integration.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { google } from 'googleapis';
+import fs from 'node:fs';
+import path from 'node:path';
+import tool from '../google_tasks.js';
+
+// Load .env into process.env for integration tests
+const envPath = path.resolve(process.cwd(), '.env');
+if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf-8').split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) continue;
+        const key = trimmed.slice(0, eq).trim();
+        const val = trimmed.slice(eq + 1).trim();
+        if (!process.env[key]) process.env[key] = val;
+    }
+}
+
+const handler = tool.handler;
+
+const hasCredentials = !!(
+    process.env.GOOGLE_CLIENT_ID &&
+    process.env.GOOGLE_CLIENT_SECRET &&
+    process.env.GOOGLE_REFRESH_TOKEN
+);
+
+// Track resources to clean up
+let testTasklistId: string;
+let createdTaskId: string;
+
+// Direct API client for cleanup (delete isn't exposed by the tool)
+function getApiClient() {
+    const oauth2Client = new google.auth.OAuth2(
+        process.env.GOOGLE_CLIENT_ID,
+        process.env.GOOGLE_CLIENT_SECRET
+    );
+    oauth2Client.setCredentials({ refresh_token: process.env.GOOGLE_REFRESH_TOKEN });
+    return google.tasks({ version: 'v1', auth: oauth2Client });
+}
+
+describe.runIf(hasCredentials)('google_tasks integration', () => {
+    afterAll(async () => {
+        // Clean up: delete the test task we created
+        if (testTasklistId && createdTaskId) {
+            try {
+                const api = getApiClient();
+                await api.tasks.delete({ tasklist: testTasklistId, task: createdTaskId });
+            } catch {
+                // Best-effort cleanup
+            }
+        }
+    });
+
+    it('list_tasklists returns at least one task list', async () => {
+        const result = await handler({ action: 'list_tasklists' }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        expect(result).toHaveProperty('tasklists');
+        expect(Array.isArray(result.tasklists)).toBe(true);
+        expect(result.tasklists.length).toBeGreaterThan(0);
+
+        // Every task list has id and title
+        for (const tl of result.tasklists) {
+            expect(tl).toHaveProperty('id');
+            expect(tl).toHaveProperty('title');
+            expect(typeof tl.id).toBe('string');
+            expect(typeof tl.title).toBe('string');
+        }
+
+        // Save the first task list for subsequent tests
+        testTasklistId = result.tasklists[0].id;
+    });
+
+    it('list_tasks returns tasks array for a task list', async () => {
+        const result = await handler({ action: 'list_tasks', tasklist_id: testTasklistId }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        expect(result).toHaveProperty('tasks');
+        expect(Array.isArray(result.tasks)).toBe(true);
+
+        // If there are tasks, verify their shape
+        for (const t of result.tasks) {
+            expect(t).toHaveProperty('id');
+            expect(t).toHaveProperty('title');
+            expect(t).toHaveProperty('status');
+            expect(['needsAction', 'completed']).toContain(t.status);
+        }
+    });
+
+    it('add_task creates a task with title, notes, and due date', async () => {
+        const result = await handler({
+            action: 'add_task',
+            tasklist_id: testTasklistId,
+            title: '[TEST] Integration test task',
+            notes: 'Created by google_tasks integration test — safe to delete',
+            due: '2026-12-31'
+        }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        expect(result).toHaveProperty('created');
+        expect(result.created.title).toBe('[TEST] Integration test task');
+        expect(result.created.status).toBe('needsAction');
+        expect(result.created.due).toBe('2026-12-31T00:00:00.000Z');
+        expect(typeof result.created.id).toBe('string');
+
+        createdTaskId = result.created.id;
+    });
+
+    it('list_tasks includes the newly created task', async () => {
+        const result = await handler({ action: 'list_tasks', tasklist_id: testTasklistId }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        const found = result.tasks.find((t: any) => t.id === createdTaskId);
+        expect(found).toBeDefined();
+        expect(found.title).toBe('[TEST] Integration test task');
+        expect(found.notes).toBe('Created by google_tasks integration test — safe to delete');
+    });
+
+    it('update_task can change title and mark completed', async () => {
+        const result = await handler({
+            action: 'update_task',
+            tasklist_id: testTasklistId,
+            task_id: createdTaskId,
+            title: '[TEST] Updated integration task',
+            status: 'completed'
+        }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        expect(result).toHaveProperty('updated');
+        expect(result.updated.id).toBe(createdTaskId);
+        expect(result.updated.title).toBe('[TEST] Updated integration task');
+        expect(result.updated.status).toBe('completed');
+    });
+
+    it('update_task can change due date', async () => {
+        const result = await handler({
+            action: 'update_task',
+            tasklist_id: testTasklistId,
+            task_id: createdTaskId,
+            due: '2027-01-15'
+        }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        expect(result.updated.due).toBe('2027-01-15T00:00:00.000Z');
+    });
+
+    it('list_tasks reflects the updates', async () => {
+        const result = await handler({ action: 'list_tasks', tasklist_id: testTasklistId }) as any;
+
+        expect(result).not.toHaveProperty('error');
+        const found = result.tasks.find((t: any) => t.id === createdTaskId);
+        expect(found).toBeDefined();
+        expect(found.title).toBe('[TEST] Updated integration task');
+        expect(found.status).toBe('completed');
+        expect(found.due).toBe('2027-01-15T00:00:00.000Z');
+    });
+});

--- a/tools/tests/google_tasks.test.ts
+++ b/tools/tests/google_tasks.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock googleapis before importing the tool
+const mockTasklistsList = vi.fn();
+const mockTasksList = vi.fn();
+const mockTasksInsert = vi.fn();
+const mockTasksPatch = vi.fn();
+
+vi.mock('googleapis', () => ({
+    google: {
+        auth: {
+            OAuth2: vi.fn().mockImplementation(function () {
+                this.setCredentials = vi.fn();
+            })
+        },
+        tasks: vi.fn().mockImplementation(function () {
+            return {
+                tasklists: { list: mockTasklistsList },
+                tasks: {
+                    list: mockTasksList,
+                    insert: mockTasksInsert,
+                    patch: mockTasksPatch
+                }
+            };
+        })
+    }
+}));
+
+import tool from '../google_tasks.js';
+
+const handler = tool.handler;
+
+describe('google_tasks tool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+        process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+        process.env.GOOGLE_REFRESH_TOKEN = 'test-refresh-token';
+    });
+
+    describe('definition', () => {
+        it('has correct name and actions', () => {
+            expect(tool.definition.name).toBe('google_tasks');
+            const actionEnum = tool.definition.parameters.properties.action.enum;
+            expect(actionEnum).toEqual(['list_tasklists', 'list_tasks', 'add_task', 'update_task']);
+        });
+
+        it('does not include a delete action', () => {
+            const actionEnum = tool.definition.parameters.properties.action.enum;
+            expect(actionEnum).not.toContain('delete_task');
+        });
+    });
+
+    describe('credential validation', () => {
+        it('returns error when GOOGLE_CLIENT_ID is missing', async () => {
+            delete process.env.GOOGLE_CLIENT_ID;
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({ error: expect.stringContaining('Missing Google credentials') });
+        });
+
+        it('returns error when GOOGLE_CLIENT_SECRET is missing', async () => {
+            delete process.env.GOOGLE_CLIENT_SECRET;
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({ error: expect.stringContaining('Missing Google credentials') });
+        });
+
+        it('returns error when GOOGLE_REFRESH_TOKEN is missing', async () => {
+            delete process.env.GOOGLE_REFRESH_TOKEN;
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({ error: expect.stringContaining('Missing Google credentials') });
+        });
+    });
+
+    describe('list_tasklists', () => {
+        it('returns formatted task lists', async () => {
+            mockTasklistsList.mockResolvedValue({
+                data: {
+                    items: [
+                        { id: 'tl1', title: 'My Tasks', kind: 'tasks#taskList' },
+                        { id: 'tl2', title: 'Work', kind: 'tasks#taskList' }
+                    ]
+                }
+            });
+
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({
+                tasklists: [
+                    { id: 'tl1', title: 'My Tasks' },
+                    { id: 'tl2', title: 'Work' }
+                ]
+            });
+        });
+
+        it('returns empty array when no task lists exist', async () => {
+            mockTasklistsList.mockResolvedValue({ data: { items: undefined } });
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({ tasklists: [] });
+        });
+    });
+
+    describe('list_tasks', () => {
+        it('returns error when tasklist_id is missing', async () => {
+            const result = await handler({ action: 'list_tasks' });
+            expect(result).toEqual({ error: 'tasklist_id is required for list_tasks' });
+        });
+
+        it('returns formatted tasks', async () => {
+            mockTasksList.mockResolvedValue({
+                data: {
+                    items: [
+                        { id: 't1', title: 'Buy milk', notes: 'Oat milk', status: 'needsAction', due: '2026-03-01T00:00:00.000Z' },
+                        { id: 't2', title: 'Call dentist', status: 'completed' }
+                    ]
+                }
+            });
+
+            const result = await handler({ action: 'list_tasks', tasklist_id: 'tl1' });
+            expect(result).toEqual({
+                tasks: [
+                    { id: 't1', title: 'Buy milk', notes: 'Oat milk', status: 'needsAction', due: '2026-03-01T00:00:00.000Z' },
+                    { id: 't2', title: 'Call dentist', notes: null, status: 'completed', due: null }
+                ]
+            });
+        });
+    });
+
+    describe('add_task', () => {
+        it('returns error when tasklist_id is missing', async () => {
+            const result = await handler({ action: 'add_task', title: 'Test' });
+            expect(result).toEqual({ error: 'tasklist_id is required for add_task' });
+        });
+
+        it('returns error when title is missing', async () => {
+            const result = await handler({ action: 'add_task', tasklist_id: 'tl1' });
+            expect(result).toEqual({ error: 'title is required for add_task' });
+        });
+
+        it('creates a task and returns it', async () => {
+            mockTasksInsert.mockResolvedValue({
+                data: { id: 't3', title: 'New task', status: 'needsAction', due: null }
+            });
+
+            const result = await handler({ action: 'add_task', tasklist_id: 'tl1', title: 'New task' });
+            expect(result).toEqual({
+                created: { id: 't3', title: 'New task', status: 'needsAction', due: null }
+            });
+        });
+
+        it('converts YYYY-MM-DD due date to RFC 3339', async () => {
+            mockTasksInsert.mockResolvedValue({
+                data: { id: 't4', title: 'With date', status: 'needsAction', due: '2026-04-15T00:00:00.000Z' }
+            });
+
+            await handler({ action: 'add_task', tasklist_id: 'tl1', title: 'With date', due: '2026-04-15' });
+
+            expect(mockTasksInsert).toHaveBeenCalledWith({
+                tasklist: 'tl1',
+                requestBody: {
+                    title: 'With date',
+                    due: '2026-04-15T00:00:00.000Z'
+                }
+            });
+        });
+
+        it('passes notes when provided', async () => {
+            mockTasksInsert.mockResolvedValue({
+                data: { id: 't5', title: 'Noted', status: 'needsAction', due: null }
+            });
+
+            await handler({ action: 'add_task', tasklist_id: 'tl1', title: 'Noted', notes: 'Some details' });
+
+            expect(mockTasksInsert).toHaveBeenCalledWith({
+                tasklist: 'tl1',
+                requestBody: {
+                    title: 'Noted',
+                    notes: 'Some details'
+                }
+            });
+        });
+    });
+
+    describe('update_task', () => {
+        it('returns error when tasklist_id is missing', async () => {
+            const result = await handler({ action: 'update_task', task_id: 't1' });
+            expect(result).toEqual({ error: 'tasklist_id is required for update_task' });
+        });
+
+        it('returns error when task_id is missing', async () => {
+            const result = await handler({ action: 'update_task', tasklist_id: 'tl1' });
+            expect(result).toEqual({ error: 'task_id is required for update_task' });
+        });
+
+        it('updates a task using patch', async () => {
+            mockTasksPatch.mockResolvedValue({
+                data: { id: 't1', title: 'Updated', status: 'completed', due: null }
+            });
+
+            const result = await handler({
+                action: 'update_task',
+                tasklist_id: 'tl1',
+                task_id: 't1',
+                title: 'Updated',
+                status: 'completed'
+            });
+
+            expect(mockTasksPatch).toHaveBeenCalledWith({
+                tasklist: 'tl1',
+                task: 't1',
+                requestBody: { title: 'Updated', status: 'completed' }
+            });
+            expect(result).toEqual({
+                updated: { id: 't1', title: 'Updated', status: 'completed', due: null }
+            });
+        });
+
+        it('converts due date in update', async () => {
+            mockTasksPatch.mockResolvedValue({
+                data: { id: 't1', title: 'Task', status: 'needsAction', due: '2026-05-01T00:00:00.000Z' }
+            });
+
+            await handler({
+                action: 'update_task',
+                tasklist_id: 'tl1',
+                task_id: 't1',
+                due: '2026-05-01'
+            });
+
+            expect(mockTasksPatch).toHaveBeenCalledWith({
+                tasklist: 'tl1',
+                task: 't1',
+                requestBody: { due: '2026-05-01T00:00:00.000Z' }
+            });
+        });
+    });
+
+    describe('error handling', () => {
+        it('returns error object on API failure', async () => {
+            mockTasklistsList.mockRejectedValue(new Error('API quota exceeded'));
+            const result = await handler({ action: 'list_tasklists' });
+            expect(result).toEqual({ error: 'API quota exceeded' });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add Google Tasks tool (list, add, update tasks via OAuth 2.0)
- Add OAuth setup script (`npm run setup:google`) for credential flow
- Add googleapis dependency
- Includes unit and integration tests

## Test plan
- [ ] Run `npm run setup:google` and complete OAuth flow
- [ ] Test listing, creating, and updating tasks through an agent
- [ ] Run unit tests: `npm test -- google_tasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)