### PR TITLE
Improve LLM tool-call reliability (Telegram, heartbeat, agent loop)

### DIFF
--- a/src/Telegram.ts
+++ b/src/Telegram.ts
@@ -131,7 +131,8 @@ export function initTelegramHandler() {
                 baseUrl: providerConfig.endpoint,
                 modelId: providerConfig.model,
                 apiKey: providerConfig.apiKey,
-                maxTokens: providerConfig.maxTokens
+                maxTokens: providerConfig.maxTokens,
+                supportsTools: !!providerConfig?.capabilities?.trained_for_tool_use
             };
 
             logger.log({

--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -511,6 +511,37 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
         }
 
         if (actualToolCalls.length > 0) {
+            // Pre-parse and sanitize each tool call's arguments BEFORE pushing the assistant message.
+            // If arguments are malformed JSON (a common failure mode on local models that over-escape
+            // quotes inside long string fields), attempt a best-effort repair. If repair fails, replace
+            // with "{}" so downstream LLM calls don't choke when re-serializing the chat history —
+            // some provider chat templates (e.g. LM Studio Jinja for qwen2.5) call fromjson on the
+            // arguments string and return 500 when it fails to parse.
+            const parsedArgsByCall: Record<string, { args: Record<string, unknown>; parseError?: string }> = {};
+            for (const toolCall of actualToolCalls) {
+                const rawArgs = toolCall.function.arguments || '{}';
+                try {
+                    parsedArgsByCall[toolCall.id] = { args: JSON.parse(rawArgs) };
+                } catch (parseErr: any) {
+                    // Attempt repair: common issue is the model emitting `\\"` instead of `\"`
+                    // when embedding quotes inside a JSON string value. Other variants: `\\\\"` (quad-backslash).
+                    const repaired = rawArgs
+                        .replace(/\\\\"/g, '\\"')
+                        .replace(/\\\\n/g, '\\n')
+                        .replace(/\\\\t/g, '\\t');
+                    try {
+                        parsedArgsByCall[toolCall.id] = { args: JSON.parse(repaired) };
+                        toolCall.function.arguments = repaired;
+                        logger.log({ type: 'system', level: 'warn', agentId: options.agentId, sessionId: options.sessionId, message: `Repaired malformed tool arguments for '${toolCall.function.name}'` });
+                    } catch (repairErr: any) {
+                        const errMsg = `Invalid tool arguments (JSON parse failed): ${parseErr.message}. Please retry with valid JSON arguments — in particular, do not double-escape quotes or newlines inside string values.`;
+                        parsedArgsByCall[toolCall.id] = { args: {}, parseError: errMsg };
+                        toolCall.function.arguments = '{}';
+                        logger.log({ type: 'error', level: 'warn', agentId: options.agentId, sessionId: options.sessionId, message: `Skipping tool call '${toolCall.function.name}': malformed JSON arguments`, data: { raw: rawArgs.substring(0, 200) } });
+                    }
+                }
+            }
+
             const assistantMsg = {
                 role: 'assistant',
                 content: fullContent || '',
@@ -527,21 +558,20 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
                 }
 
                 const name = toolCall.function.name;
-                let args: Record<string, unknown>;
-                try {
-                    args = JSON.parse(toolCall.function.arguments || '{}');
-                } catch (parseErr: any) {
-                    // Malformed JSON from the LLM — report it back as a tool error so the agent can self-correct
-                    logger.log({ type: 'error', level: 'warn', agentId: options.agentId, sessionId: options.sessionId, message: `Skipping tool call '${name}': malformed JSON arguments`, data: { raw: toolCall.function.arguments?.substring(0, 200) } });
+                const parsed = parsedArgsByCall[toolCall.id];
+
+                if (parsed.parseError) {
                     chatHistory.push({
                         role: 'tool',
                         tool_call_id: toolCall.id,
                         name,
-                        content: JSON.stringify({ error: `Invalid tool arguments (JSON parse failed): ${parseErr.message}. Please retry with valid JSON arguments.` }),
+                        content: JSON.stringify({ error: parsed.parseError }),
                         timestamp: Math.floor(Date.now() / 1000)
                     });
                     continue;
                 }
+
+                const args = parsed.args;
 
                 console.log(`[Tool Execution] Calling tool '${name}' with arguments:`, JSON.stringify(args, null, 2));
 
@@ -583,9 +613,12 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
                     const details = getToolDetails(name, args);
                     AgentManager.setAgentState(options.agentId, 'working', details);
 
-                    // Resolve per-tool config: agent config overrides global entirely
+                    // Resolve per-tool config: agent config overrides global entirely.
+                    // Tools in subdirectories (e.g. github_create) share config under the prefix (e.g. github).
                     const globalToolsConfig = loadConfig().tools;
-                    const toolConfig = options.agentToolsConfig?.[name] ?? globalToolsConfig?.[name];
+                    const configKey = name.includes('_') ? name.split('_')[0] : name;
+                    const toolConfig = options.agentToolsConfig?.[name] ?? options.agentToolsConfig?.[configKey]
+                        ?? globalToolsConfig?.[name] ?? globalToolsConfig?.[configKey];
 
                     let result;
                     const toolStartTime = Date.now();

--- a/src/heartbeat-manager.ts
+++ b/src/heartbeat-manager.ts
@@ -171,24 +171,23 @@ Please execute these instructions now.
                 agentToolsConfig: agent.tools
             });
 
-            // Parse thinking content
-            let contentToLog = fullContent;
+            // Strip all thinking/reasoning tags from output
+            const thinkRegex = /<(think|thought|reasoning)>[\s\S]*?<\/\1>/gi;
+            // Also handle unclosed think blocks (model forgot to close or was truncated)
+            const unclosedThinkRegex = /<(think|thought|reasoning)>[\s\S]*$/i;
+
             let thinkingContent = '';
+            const thinkMatches = fullContent.match(thinkRegex);
+            if (thinkMatches) {
+                thinkingContent = thinkMatches.map(m => m.replace(/<\/?(?:think|thought|reasoning)>/gi, '').trim()).join('\n');
+            }
 
-            const thinkStart = fullContent.indexOf('<think>');
-            const thinkEnd = fullContent.indexOf('</think>');
-
-            if (thinkStart !== -1) {
-                if (thinkEnd !== -1) {
-                    // Complete think block
-                    thinkingContent = fullContent.substring(thinkStart + 7, thinkEnd).trim();
-                    contentToLog = fullContent.substring(0, thinkStart) + fullContent.substring(thinkEnd + 8);
-                } else {
-                    // Incomplete think block (model forgot to close or was truncated)
-                    // We treat everything after <think> as thinking content
-                    thinkingContent = fullContent.substring(thinkStart + 7).trim();
-                    contentToLog = fullContent.substring(0, thinkStart);
-                }
+            let contentToLog = fullContent.replace(thinkRegex, '');
+            // Handle unclosed block if no closed blocks were found at the tail
+            const unclosedMatch = contentToLog.match(unclosedThinkRegex);
+            if (unclosedMatch) {
+                thinkingContent += (thinkingContent ? '\n' : '') + unclosedMatch[0].replace(/<(?:think|thought|reasoning)>/gi, '').trim();
+                contentToLog = contentToLog.replace(unclosedThinkRegex, '');
             }
             contentToLog = contentToLog.trim();
 
@@ -280,6 +279,7 @@ Please execute these instructions now.
                 baseUrl: providerConfig.endpoint,
                 modelId: providerConfig.model,
                 apiKey: providerConfig.apiKey,
+                maxTokens: providerConfig.maxTokens,
                 supportsTools: !!providerConfig?.capabilities?.trained_for_tool_use
             };
 
@@ -320,21 +320,21 @@ You have been woken up to work on the Agent Collaboration System.
                 signToolUrls: false
             });
 
-            // Parse thinking content
-            let contentToLog = fullContent;
+            // Strip all thinking/reasoning tags from output
+            const thinkRegex = /<(think|thought|reasoning)>[\s\S]*?<\/\1>/gi;
+            const unclosedThinkRegex = /<(think|thought|reasoning)>[\s\S]*$/i;
+
             let thinkingContent = '';
+            const thinkMatches = fullContent.match(thinkRegex);
+            if (thinkMatches) {
+                thinkingContent = thinkMatches.map(m => m.replace(/<\/?(?:think|thought|reasoning)>/gi, '').trim()).join('\n');
+            }
 
-            const thinkStart = fullContent.indexOf('<think>');
-            const thinkEnd = fullContent.indexOf('</think>');
-
-            if (thinkStart !== -1) {
-                if (thinkEnd !== -1) {
-                    thinkingContent = fullContent.substring(thinkStart + 7, thinkEnd).trim();
-                    contentToLog = fullContent.substring(0, thinkStart) + fullContent.substring(thinkEnd + 8);
-                } else {
-                    thinkingContent = fullContent.substring(thinkStart + 7).trim();
-                    contentToLog = fullContent.substring(0, thinkStart);
-                }
+            let contentToLog = fullContent.replace(thinkRegex, '');
+            const unclosedMatch = contentToLog.match(unclosedThinkRegex);
+            if (unclosedMatch) {
+                thinkingContent += (thinkingContent ? '\n' : '') + unclosedMatch[0].replace(/<(?:think|thought|reasoning)>/gi, '').trim();
+                contentToLog = contentToLog.replace(unclosedThinkRegex, '');
             }
             contentToLog = contentToLog.trim();
 


### PR DESCRIPTION
## Summary

Three related fixes for agents that rely on tool-calling models, all surfaced while debugging local-model agents (Qwen via LM Studio) that were inconsistently calling tools and occasionally crashing the provider with 500s.

### 1. \`src/Telegram.ts\` — pass \`supportsTools\` to the agent loop

Telegram chat sessions were constructing \`llmConfig\` without \`supportsTools\`, so the agent loop passed \`undefined\` for the tools array — agents silently had zero tools available when replying to Telegram DMs, regardless of their provider's \`trained_for_tool_use\` capability. Heartbeat and web chat already set this flag; Telegram just needed to match.

### 2. \`src/agent-loop.ts\` — auto-repair malformed tool_call arguments

Local tool-calling models (observed on Qwen2.5-coder via LM Studio streaming) sometimes emit over-escaped quote/newline sequences inside JSON string values — e.g. \`\\\\\"\` where \`\\\"\` was meant, especially when embedding long multi-line strings. The raw arguments then fail \`JSON.parse\`, and — critically — the assistant message carrying the broken args still gets pushed into chat history. The next provider call can then 500 when the chat template's Jinja re-serialises the malformed arguments (reproduced against LM Studio's qwen2.5 template).

This change:

- Pre-parses each tool call's arguments **before** pushing the assistant message
- On parse failure, attempts a best-effort unescape pass (\`\\\\\"\` → \`\\\"\`, \`\\\\n\` → \`\\n\`, \`\\\\t\` → \`\\t\`)
- If repair succeeds, updates \`toolCall.function.arguments\` in place so subsequent history renders stay clean; logs a warning
- If repair fails, replaces arguments with \`"{}"\` and feeds the original parse error back to the model as a tool_result so it can retry
- Also fixes per-tool config resolution for subdirectory tools: \`github_create\` etc. now inherit config from the \`github\` prefix the same way a single github tool would

### 3. \`src/heartbeat-manager.ts\` — robust thinking-tag stripping

Replaces the \`indexOf('<think>')\` approach with a regex that handles:

- Multiple \`<think>\` blocks in one response (some thinking models emit several)
- \`<thought>\` and \`<reasoning>\` variants
- Unclosed blocks (model truncation or forgotten close tag)

Applied to both the heartbeat and collaboration code paths.

## Test plan

- [ ] Heartbeat with a \`trained_for_tool_use: true\` provider → agent emits real \`tool_calls\` (reproduced on qwen2.5-coder via LM Studio and Claude Haiku)
- [ ] Telegram DM to the same agent → agent has access to tools (previously received zero)
- [ ] Streaming tool call with long multi-line string argument containing embedded quotes → JSON auto-repair logs a warning and the call executes instead of being skipped
- [ ] Subdirectory tool (\`github_create\`) picks up config from the \`github\` prefix in agent or global tools config
- [ ] Response containing multiple \`<think>\` blocks or an unclosed one → thinking content captured, clean content emitted to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)