### PR TITLE
Filter tools exposed to an agent by its declared `tools` block

### DIFF
--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -252,6 +252,46 @@ function getToolDetails(name: string, args: any): string {
     }
 }
 
+/**
+ * Filter the tool definitions exposed to an agent based on its `tools` block.
+ *
+ * - If the agent has no `tools` block (or an empty one), returns all definitions
+ *   unchanged — this is the pre-existing default and preserves backward
+ *   compatibility for agents that haven't opted in to scoped tool surfaces.
+ * - If the agent has a non-empty `tools` block, only tools whose name (or
+ *   underscore prefix, for subdirectory tools like `github_create` → `github`)
+ *   appear as a key in that block are included. Core tools from `tools/core/`
+ *   and built-in registered tools (memory, workflows, skills) are always
+ *   available regardless — they're infrastructure, not opt-in capabilities.
+ *
+ * This lets agent authors declare exactly which external tools a given agent
+ * should see, preventing a drafting agent from accidentally calling a
+ * publishing tool that should belong to a downstream delegate.
+ */
+function filterToolsForAgent(
+    defs: ReturnType<typeof ToolManager.getToolDefinitions>,
+    agentToolsConfig: Record<string, any> | undefined
+): typeof defs {
+    if (!agentToolsConfig || Object.keys(agentToolsConfig).length === 0) {
+        return defs;
+    }
+    return defs.filter(def => {
+        // Core tools (tools/core/*) and built-in registered tools (no filename)
+        // are always available — they are infrastructure, not optional capabilities.
+        const filename = def.filename;
+        if (!filename) return true;
+        if (filename.startsWith('core/') || filename.startsWith('core\\')) return true;
+
+        // External tool: must be declared in the agent's tools block, either
+        // by exact name or by the underscore prefix for subdirectory tools
+        // (e.g. a tool named `github_create` matches the key `github`).
+        const name = def.name;
+        if (agentToolsConfig[name]) return true;
+        const prefix = name.includes('_') ? name.split('_')[0] : name;
+        return !!agentToolsConfig[prefix];
+    });
+}
+
 export interface AgentLoopOptions {
     agentId: string;
     sessionId: string;
@@ -331,10 +371,13 @@ export async function runAgentLoop(options: AgentLoopOptions): Promise<AgentLoop
         const requestStartTime = Date.now();
 
         try {
+            const toolDefsForAgent = options.llmConfig.supportsTools
+                ? filterToolsForAgent(ToolManager.getToolDefinitions(), options.agentToolsConfig)
+                : undefined;
             for await (const delta of streamChatCompletion(
                 options.llmConfig,
                 processedHistory,
-                options.llmConfig.supportsTools ? ToolManager.getToolDefinitions() : undefined,
+                toolDefsForAgent,
                 options.abortSignal
             )) {
                 if (delta.content) {


### PR DESCRIPTION
## Problem

\`src/agent-loop.ts\` currently calls \`ToolManager.getToolDefinitions()\` to build the tool surface for every agent, returning **all** globally-enabled tools regardless of what the agent's \`config.json\` declares in its \`tools\` block. The \`tools\` block is only consulted later, at execution time, to pass per-tool config data to the handler — it has never gated what the model can *see*.

In practice this means an agent with a narrowly-scoped config like:

\`\`\`json
{
  \"tools\": {
    \"github\": { \"repos\": { ... } }
  }
}
\`\`\`

…still sees every other enabled plugin tool (\`buffer\`, \`linkedin\`, \`postgres\`, \`qdrant\`, \`weather\`, \`google_calendar\`, etc.) in its tool surface. Capabilities leak across agent boundaries, so a drafting agent can directly invoke a publishing tool that was supposed to live behind a delegate (\`agent → publisher → buffer.create_post\`), bypassing whatever guardrails the delegate was supposed to provide.

This came up while debugging a marketing / publisher agent split: the marketing agent's prompt said \"delegate to publisher\", and it did, but \`buffer\` was still in its tool surface because of the global tool list. Prompt-based enforcement is OK, but it's not the same as not offering the tool at all.

## Change

Adds a \`filterToolsForAgent\` helper in \`src/agent-loop.ts\` that narrows the tool list before it's handed to \`streamChatCompletion\`. Rules:

1. **No \`tools\` block or empty block → no filtering.** Fully backward compatible. Existing agents that haven't opted in to scoped surfaces keep seeing every enabled tool.
2. **Non-empty \`tools\` block → strict filter.** Only tools whose name (or underscore prefix for subdirectory tools, e.g. \`github_create\` → \`github\`) appear as a key in the block are included.
3. **Core and built-in tools are always available.** Tools loaded from \`tools/core/*\` and built-ins registered programmatically (memory_*, workflows, skills) bypass the filter unconditionally — they're infrastructure, not opt-in capabilities.

The other two \`getToolDefinitions()\` call sites in \`agent-loop.ts\` are lookups for tool metadata (displayName, pluginType, requiresApproval) *after* the model has chosen a tool. Those aren't filtered — they need to find the definition even if something goes wrong upstream, and filtering them would silently drop legitimate metadata.

## Migration notes

- **Zero-impact** for any agent that either (a) has no \`tools\` block, or (b) already listed every external tool they use.
- Agents with a sparsely-declared \`tools\` block (e.g. declares only \`github\` but actually uses \`buffer\` through a prompt workaround) will immediately see a narrower surface. This is the desired behaviour but worth a line in release notes if anyone was relying on the leak.

## Related

- Depends conceptually on the subdirectory tool config resolution introduced in #88 (so that a config key of \`github\` matches tool names \`github_create\`, \`github_list\`, etc.). That same prefix-matching logic is used here.
- Complements #89 (Buffer tool) by letting admins scope buffer to a dedicated publisher agent instead of every agent seeing it.

## Test plan

- [ ] Agent with no \`tools\` block → sees every enabled tool, just like before
- [ ] Agent with \`tools: { github: {} }\` → sees \`github_*\` tools + core/built-ins, does **not** see \`buffer\`, \`linkedin\`, \`weather\`, etc.
- [ ] Subagent called via \`agent\` tool retains its own filtered surface (the sub-loop already passes its own \`agentToolsConfig\`)
- [ ] Agent's heartbeat and Telegram chat both respect the filter (both go through \`runAgentLoop\` with the same \`options.agentToolsConfig\`)
- [ ] \`requiresApproval\` and tool-not-found metadata lookups still work (they use unfiltered \`getToolDefinitions()\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)